### PR TITLE
fix: pre-commit ci on push to main

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,12 +2,14 @@ name: pre-commit
 
 on:
   pull_request:
-  push:
     branches: [main]
+
+  workflow_dispatch:
 
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,11 +3,6 @@ name: tests
 on:
   pull_request:
     branches: [main]
-    paths:
-      - ".github/workflows/tests.yml"
-      - "Inc/**"
-      - "Src/**"
-      - "Tests/**"
 
   workflow_dispatch:
 


### PR DESCRIPTION
Pre-commit CI cannot run on push to main, otherwise it will fail because we cannot push to this branch.