### PR TITLE
ci: add ceedling vs code extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,8 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "ms-vscode.cpptools"
+                "ms-vscode.cpptools",
+                "numaru.vscode-ceedling-test-adapter"
             ],
             "settings": {
                 "terminal.integrated.defaultProfile.linux": "bash"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Ceedling Test Explorer Debug",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/Tests/build/test/out/${command:ceedlingExplorer.debugTestExecutable}",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "/usr/bin/gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In this example, the unit tests are run exclusively on the developer's machine
 streamline this process among developers, the project uses a Docker environment
 described below (see [running unit tests](#running-unit-tests)).
 
-## Hardware
+## Required Hardware
 
 1. Breadboard
 2. Microcontroller (ATmega168A, 28-PDIP Package)
@@ -26,7 +26,7 @@ described below (see [running unit tests](#running-unit-tests)).
 Details on how to connect these components can be found in
 ```Docs/schematic.pdf```.
 
-## Running unit tests
+## Running unit tests manually
 
 This project uses a Dockerized environment from within which the unit tests can
 be executed. This saves developers from having to set up the development
@@ -37,17 +37,25 @@ installed and running on your machine. Next, install and activate the
 [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
 extension for [Visual Studio Code](https://code.visualstudio.com/).
 
-Opening the workspace should then allow you to reopen the project in a container
-with all required packages already installed. From within the ```Tests/```
+Opening the workspace in Visual Studio Code should then prompt you with a
+textbox that allows you to reopen the project in a Docker container with all
+required packages already installed. From within the ```Tests/```
 directory, you can then simply run:
 
 ```bash
 ceedling test:all
 ```
 
-This should show that all tests are passing successfully:
+All tests should pass successfully:
 
 ![All unit tests ran successfully.](Docs/Img/run-unit-tests.gif)
+
+## VS Code Extension
+
+As an alternative, you can also use run the unit tests directly from
+within VS Code by using the [Ceedling Test Explorer](https://marketplace.visualstudio.com/items?itemName=numaru.vscode-ceedling-test-adapter) plugin. The plugin not only provides a convenient
+interface to launch unit tests for individual models from, but also adds
+integration of the GDB debugger.
 
 ## Further reading
 

--- a/Tests/project.yml
+++ b/Tests/project.yml
@@ -100,4 +100,5 @@
   :enabled:
     - stdout_pretty_tests_report
     - module_generator
+    - xml_tests_report
 ...

--- a/atmega-tdd-example.code-workspace
+++ b/atmega-tdd-example.code-workspace
@@ -21,6 +21,8 @@
             "microcontroller",
             "PDIP",
             "Pololu"
-        ]
+        ],
+        "ceedlingExplorer.projectPath": "./Tests",
+        "ceedlingExplorer.debugConfiguration": "Ceedling Test Explorer Debug"
     }
 }

--- a/packages.txt
+++ b/packages.txt
@@ -6,6 +6,7 @@ clang-tidy
 cmake
 gcc
 gcc-avr
+gdb
 git
 make
 nano


### PR DESCRIPTION
Adds VS Code extension to the project that integrates unit tests with Ceedling and debugging them using GDB.