### PR TITLE
chore: cleanup cmake tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,18 +39,13 @@ extension for [Visual Studio Code](https://code.visualstudio.com/).
 
 Opening the workspace in Visual Studio Code should then prompt you with a
 textbox that allows you to reopen the project in a Docker container with all
-required packages already installed. You can then simply use `CMake` to first
-build for the `test` group and then use `CTest` to invoke the tests:
+required packages already installed. To invoke all unit tests, simply run:
 
 ```bash
-mkdir -p Build
-cd Build
-cmake -DTARGET_GROUP=test ..
-cmake --build .
-ctest Tests/ -V
+./unit-tests.sh
 ```
 
-All tests should pass successfully:
+This should show that all tests passing:
 
 ![All unit tests ran successfully.](Docs/run-unit-tests.jpg)
 

--- a/Tests/.gitignore
+++ b/Tests/.gitignore
@@ -1,1 +1,2 @@
 [Bb]uild/
+[Tt]esting/

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -6,34 +6,25 @@ FetchContent_Declare(
   GIT_TAG v2.6.0
 )
 
-FetchContent_Declare(
-  fff
-  GIT_REPOSITORY https://github.com/meekrosoft/fff.git
-  GIT_TAG v1.1
-)
+FetchContent_MakeAvailable(unity)
 
-FetchContent_MakeAvailable(unity fff)
+# download fff.h directly, since meekrosoft/fff does not work with FetchContent
+set(FFF_DIR "${CMAKE_BINARY_DIR}/_deps/fff")
 
-add_executable(test_led test_led.c ${CMAKE_SOURCE_DIR}/Src/led.c)
-target_compile_definitions(test_led PUBLIC TEST)
-target_include_directories(test_led PRIVATE ${CMAKE_SOURCE_DIR}/Inc support)
-target_link_libraries(test_led unity)
-add_test(test_led test_led)
+file(DOWNLOAD
+     "https://github.com/meekrosoft/fff/releases/download/v1.1/fff.h"
+     "${FFF_DIR}/fff.h")
 
-add_executable(test_main test_main.c ${CMAKE_SOURCE_DIR}/Src/main.c)
-target_compile_definitions(test_main PUBLIC TEST)
-target_include_directories(test_main PRIVATE ${CMAKE_SOURCE_DIR}/Inc support ${CMAKE_BINARY_DIR}/_deps/fff-src)
-target_link_libraries(test_main unity)
-add_test(test_main test_main)
+# define function to create unit test executables
+function(create_test module_name)
+  add_executable(test_${module_name} test_${module_name}.c ${CMAKE_SOURCE_DIR}/Src/${module_name}.c)
+  target_compile_definitions(test_${module_name} PUBLIC TEST)
+  target_include_directories(test_${module_name} PRIVATE ${CMAKE_SOURCE_DIR}/Inc support ${FFF_DIR})
+  target_link_libraries(test_${module_name} PUBLIC unity)
+  add_test(test_${module_name} test_${module_name})
+endfunction()
 
-add_executable(test_timer test_timer.c ${CMAKE_SOURCE_DIR}/Src/timer.c)
-target_compile_definitions(test_timer PUBLIC TEST)
-target_include_directories(test_timer PRIVATE ${CMAKE_SOURCE_DIR}/Inc support)
-target_link_libraries(test_timer unity)
-add_test(test_timer test_timer)
-
-add_executable(test_superloop test_superloop.c ${CMAKE_SOURCE_DIR}/Src/superloop.c)
-target_compile_definitions(test_superloop PUBLIC TEST)
-target_include_directories(test_superloop PRIVATE ${CMAKE_SOURCE_DIR}/Inc support ${CMAKE_BINARY_DIR}/_deps/fff-src)
-target_link_libraries(test_superloop unity)
-add_test(test_superloop test_superloop)
+create_test(led)
+create_test(main)
+create_test(superloop)
+create_test(timer)

--- a/build-app.sh
+++ b/build-app.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eou pipefail
+
+build_dir=Build
+
+rm -rf $build_dir/
+mkdir -p $build_dir/
+cmake -S . -B $build_dir/
+cmake --build $build_dir/

--- a/clang-tidy.sh
+++ b/clang-tidy.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eou pipefail
+
 checker=clang-tidy
 dummy_file=dummyfile
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build: .
   build-hex:
     image: atmega-tdd
-    command: bash -c "mkdir -p Build && cd Build && cmake .. && cmake --build ."
+    command: bash -c "chmod +x build-app.sh && ./build-app.sh"
     depends_on:
     - build-image
     volumes:
@@ -19,7 +19,7 @@ services:
     - ./:/app
   unit-tests:
     image: atmega-tdd
-    command: bash -c "mkdir -p Build && cd Build && cmake -DTARGET_GROUP=test .. && cmake --build . && ctest Tests/ -V"
+    command: bash -c "chmod +x unit-tests.sh && ./unit-tests.sh"
     depends_on:
     - build-image
     volumes:

--- a/unit-tests.sh
+++ b/unit-tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -eou pipefail
+
+build_dir=Build
+
+rm -rf $build_dir/
+mkdir -p $build_dir/
+cmake -DTARGET_GROUP=test -S . -B $build_dir/
+cmake --build $build_dir/
+ctest --test-dir $build_dir/Tests/ -V


### PR DESCRIPTION
Cleanup `CMake` files by making it easier to create unit test executables from a single function call.+